### PR TITLE
Chrome needs the manifest.json filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ So you do have to install this manually.
 
 1. Download the [files from this repo](https://github.com/cptpiepmatz/great-on-deck-search/archive/refs/heads/main.zip)
 2. Unpack the files in a directory of your choice, just make sure that you need these files as long you want to use the extension
-3. Go to `chrome://extensions/` in your browser (this should also work in chrome-based browsers)
-4. Select *Load unpacked* and select your directory with the unpacked files
-5. And you're done!
+3. Rename either chrome or firefox manifest file to `manifest.json` depending on your browser of choice.
+4. Go to `chrome://extensions/` in your browser (this should also work in chrome-based browsers)
+5. Select *Load unpacked* and select your directory with the unpacked files
+6. And you're done!


### PR DESCRIPTION
I'm not sure about firefox. This is all pure speculation, I didn't bother to read the docs - when I saw the error trying to load the extension on chrome, I tried renaming the manifest and it worked.