### PR TITLE
Added Nav Button to App Page and improved Compability with SteamDB extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+
+manifest.json

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -30,6 +30,18 @@
 }
 
 /* App Page Styles */
+.apphub_OtherSiteInfo {
+    display: flex;
+    gap: 4px;
+}
+.protondb-nav-button {
+    order: -5;
+}
+.protondb-nav-button img {
+    filter: brightness(0) invert(1);
+    background: none;
+}
+
 .protondb-logo-proton,
 .protondb-logo-db {
     font-family: "Rationale", sans-serif;


### PR DESCRIPTION
This adds a nav button next to the `Community Hub` button linking to the ProtonDB entry.

It should not conflict with other extensions adding a button up there too. The ProtonDB button will be the most left in all cases.

![image](https://user-images.githubusercontent.com/3590829/178552962-429afcee-8570-4449-a3e6-f0e415460bdd.png)

While working on this, I improved the compability with the SteamDB extension for browsers. This improved is very generalized and does not explicitly mention SteamDB.

This will close #5.