### PR TITLE
Integrate Steam Deck HQ Game Review Ratings in the Extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -61,7 +61,7 @@ async function fetchDeckVerified(appId) {
     appId,
     `https://www.protondb.com/proxy/steam/deck-verified?nAppID=${appId}`
   );
-  return data.results ?? null;
+  return data?.results ?? null;
 }
 
 /**

--- a/background.js
+++ b/background.js
@@ -56,11 +56,12 @@ async function fetchProtonDb(appId) {
  * @return {Promise<{resolved_category: (0|1|2|3)}|null>}
  */
 async function fetchDeckVerified(appId) {
-  return await cachedFetch(
+  let data = await cachedFetch(
     deckVerifiedCache,
     appId,
     `https://www.protondb.com/proxy/steam/deck-verified?nAppID=${appId}`
   );
+  return data.results;
 }
 
 /**

--- a/background.js
+++ b/background.js
@@ -61,7 +61,7 @@ async function fetchDeckVerified(appId) {
     appId,
     `https://www.protondb.com/proxy/steam/deck-verified?nAppID=${appId}`
   );
-  return data.results;
+  return data.results ?? null;
 }
 
 /**

--- a/background.js
+++ b/background.js
@@ -13,13 +13,29 @@ const MessageType = {
 const protonDbCache = new Map();
 
 /**
+ * Utility function to fetch data while also using a cache.
+ * @param {Map} cache
+ * @param {number | string} requestId
+ * @param {string} fetchUrl
+ */
+async function cachedFetch(cache, requestId, fetchUrl) {
+  if (!requestId) return null;
+  if (cache.has(requestId)) return cache.get(requestId);
+  let res = await fetch(fetchUrl);
+  if (res.ok) {
+    let json = await res.json();
+    cache.set(requestId, json);
+    return json;
+  }
+  cache.set(requestId, null);
+  return null;
+}
+
+/**
  * Cache for the Deck Verifications.
  * @type {Map<string, null | {resolved_category: 0 | 1 | 2 | 3}>}
  */
 const deckVerifiedCache = new Map();
-
-/** Cache for the Steam Deck HQ game review ratings. */
-const sdhqRatingCache = new Map();
 
 /**
  * Fetches ProtonDB entries.
@@ -27,18 +43,11 @@ const sdhqRatingCache = new Map();
  * @return {Promise<null|{tier: string}>}
  */
 async function fetchProtonDb(appId) {
-  if (!appId) return null;
-  if (protonDbCache.has(appId)) return protonDbCache.get(appId);
-  let res = await fetch(`https://www.protondb.com/api/v1/reports/summaries/${appId}.json`);
-  switch (res.ok) {
-    case false:
-      protonDbCache.set(appId, null);
-      return null;
-    case true:
-      let json = await res.json();
-      protonDbCache.set(appId, json);
-      return json;
-  }
+  return await cachedFetch(
+    protonDbCache,
+    appId,
+    `https://www.protondb.com/api/v1/reports/summaries/${appId}.json`
+  );
 }
 
 /**
@@ -47,39 +56,83 @@ async function fetchProtonDb(appId) {
  * @return {Promise<{resolved_category: (0|1|2|3)}|null>}
  */
 async function fetchDeckVerified(appId) {
-  if (!appId) return null;
-  if (deckVerifiedCache.has(appId)) return deckVerifiedCache.get(appId);
-  let res = await fetch(`https://www.protondb.com/proxy/steam/deck-verified?nAppID=${appId}`);
-  switch (res.ok) {
-    case false:
-      deckVerifiedCache.set(appId, null);
-      return null;
-    case true:
-      let json = await res.json();
-      deckVerifiedCache.set(appId, json.results);
-      return json.results;
-  }
+  return await cachedFetch(
+    deckVerifiedCache,
+    appId,
+    `https://www.protondb.com/proxy/steam/deck-verified?nAppID=${appId}`
+  );
 }
+
+/**
+ * A numerical ranking between 1 and 5.
+ * @typedef {1 | 2 | 3 | 4 | 5} rating
+ */
+
+/**
+ * The data received from the Steam Deck HQ game ratings page.
+ * @typedef {[undefined | {
+ *   acf: {
+ *     sdhq_rating: rating,
+ *     sdhq_rating_categories: {
+ *       performance: rating,
+ *       visuals: rating,
+ *       stability: rating,
+ *       controls: rating,
+ *       battery: rating,
+ *       score_breakdown: string
+ *     }
+ *   },
+ *   link: string,
+ *   author: number,
+ *   author_meta: {
+ *     author_link: string,
+ *     display_name: string
+ *   }
+ * }]} sdhq_rating
+ */
+
+/** Cache for the Steam Deck HQ game review ratings. */
+const sdhqRatingCache = new Map();
 
 /**
  * Fetches Steam Deck HQ game review ratings.
  * @param {string} appId ID of the app to fetch
- * @return {Promise<{acf: {sdhq_rating: number}, link: string, title: {rendered: string}} | null>}
+ * @return {Promise<sdhq_rating[0] | null>}
  */
 async function fetchSteamDeckHQRating(appId) {
-  if (!appId) return null;
-  if (sdhqRatingCache.has(appId)) return sdhqRatingCache.get(appId);
-  let res = await fetch(`https://steamdeckhq.com/wp-json/wp/v2/game-reviews/?meta_key=steam_app_id&meta_value=${appId}&_fields=title,acf.sdhq_rating,link`);
-  switch (res.ok) {
-    case false:
-      sdhqRatingCache.set(appId, null);
-      return null;
-    case true:
-      let json = await res.json();
-      let data = json[0] ?? null;
-      sdhqRatingCache.set(appId, data);
-      return data;
-  }
+  let data = await cachedFetch(
+    sdhqRatingCache,
+    appId,
+    `https://steamdeckhq.com/wp-json/wp/v2/game-reviews/?meta_key=steam_app_id&meta_value=${appId}`
+  );
+  return data ? data[0] ?? null : null;
+}
+
+/** Cache for the author avatars. */
+const sdhqAuthorAvatarCache = new Map();
+
+/**
+ * Fetches Steam Deck HQ author avatar data.
+ * @param {number} authorId ID of the author to fetch avatar for
+ * @return {Promise<{mpp_avatar: {[24 | 48 | 96 | 150 | 300 | full]: string}} | null>}
+ */
+async function fetchSteamDeckHQAuthorAvatar(authorId) {
+  return await cachedFetch(
+    sdhqAuthorAvatarCache,
+    authorId,
+    `https://steamdeckhq.com/wp-json/wp/v2/users/${authorId}`
+  );
+}
+
+/**
+ * Fetches Steam Deck HQ game review and author avatar data.
+ * @param appId
+ * @return {Promise<{rating: sdhq_rating[0] | null, avatar: {mpp_avatar: {[24 | 48 | 96 | 150 | 300 | full]: string}} | null}>}
+ */
+async function fetchSteamDeckHQData(appId) {
+  let rating = await fetchSteamDeckHQRating(appId);
+  let avatar = await fetchSteamDeckHQAuthorAvatar(rating?.author);
+  return {rating, avatar};
 }
 
 chrome.runtime.onConnect.addListener(port => {
@@ -101,7 +154,7 @@ chrome.runtime.onConnect.addListener(port => {
         return port.postMessage({
           type,
           appId,
-          data: await fetchSteamDeckHQRating(appId)
+          data: await fetchSteamDeckHQData(appId)
         });
       case MessageType.ALL:
         return port.postMessage({
@@ -110,7 +163,7 @@ chrome.runtime.onConnect.addListener(port => {
           data: {
             protonDb: await fetchProtonDb(appId),
             deckVerified: await fetchDeckVerified(appId),
-            sdhq: await fetchSteamDeckHQRating(appId)
+            sdhq: await fetchSteamDeckHQData(appId)
           }
         });
       default: console.error(new Error(`${type} unknown`));

--- a/chrome.manifest.json
+++ b/chrome.manifest.json
@@ -16,7 +16,8 @@
   ],
   "host_permissions": [
     "https://store.steampowered.com/*",
-    "https://www.protondb.com/app/*"
+    "https://www.protondb.com/app/*",
+    "https://steamdeckhq.com/*"
   ],
   "icons": {
     "16": "icon/icon16.png",

--- a/contentScript.js
+++ b/contentScript.js
@@ -133,7 +133,7 @@ function handleSearchResults() {
         let sdhqRatingHtml = `
         <div class="sdhq-search-rating">
           <a target="_blank" href="${data.sdhq.rating.link}">
-            <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/rating-${data.sdhq.rating.acf.sdhq_rating}-star.svg">
+            <img src="https://steamdeckhq.com/misc/rating-${data.sdhq.rating.acf.sdhq_rating}-star.svg">
           </a>
         </div>
         `;
@@ -219,7 +219,7 @@ function handleAppPage() {
           <div class="sdhq-review-row">
             <img 
               class="sdhq-star-rating" 
-              src="https://steamdeckhq.com/wp-content/uploads/2022/06/rating-${rating.acf.sdhq_rating}-star.svg"
+              src="https://steamdeckhq.com/misc/rating-${rating.acf.sdhq_rating}-star.svg"
               data-tooltip-text="
                 Performance: ${cats.performance}; 
                 Visuals: ${cats.visuals};
@@ -339,7 +339,7 @@ function handleFrontPage() {
         let sdhqRatingHtml = `
         <div class="sdhq-front-page">
           <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/sdhq-logo.svg" height="30px">
-          <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/rating-${data.rating.acf.sdhq_rating}-star.svg" height="25px">
+          <img src="https://steamdeckhq.com/misc/rating-${data.rating.acf.sdhq_rating}-star.svg" height="25px">
         </div>
         `;
         let sdhqRatingElement = parser

--- a/contentScript.js
+++ b/contentScript.js
@@ -187,7 +187,7 @@ function handleAppPage() {
       let cats = rating.acf.sdhq_rating_categories;
       let sdhqHtml = `
       <div class=block responsive_apppage_details_right">
-        <a href="${rating.link}">
+        <a href="${rating.link}" target="_blank">
           <div class="sdhq-logo">
             <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/sdhq-logo.svg"></img>
           </div>

--- a/contentScript.js
+++ b/contentScript.js
@@ -117,6 +117,31 @@ function handleSearchResults() {
       if (deckVerified) iconRow.append(deckVerifiedIcon);
       let protonDbMedal = createProtonDbMedal(appId, protonDb?.tier);
       if (protonDbMedal) iconRow.append(protonDbMedal);
+
+      if (!data.sdhq || !data.sdhq.rating) return;
+      let releasedRow = row.querySelector(".search_released");
+      if (releasedRow) {
+
+        let dateText = releasedRow.innerText;
+        if (dateText) {
+          releasedRow.innerText = "";
+          let dateDiv = document.createElement("div");
+          dateDiv.innerText = dateText;
+          releasedRow.append(dateDiv);
+        }
+
+        let sdhqRatingHtml = `
+        <div class="sdhq-search-rating">
+          <a target="_blank" href="${data.sdhq.rating.link}">
+            <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/rating-${data.sdhq.rating.acf.sdhq_rating}-star.svg">
+          </a>
+        </div>
+        `;
+        let sdhqRatingElement = parser
+          .parseFromString(sdhqRatingHtml, "text/html")
+          .querySelector("div");
+        releasedRow.append(sdhqRatingElement);
+      }
     });
 
     // request data from background service

--- a/contentScript.js
+++ b/contentScript.js
@@ -330,9 +330,9 @@ function handleFrontPage() {
       let hero = appHeroes.get(appId);
       if (!hero) return;
       let platforms = hero.querySelector(".platforms");
-      let verifiedIcon = createDeckVerifiedIcon(data.deckVerified.resolved_category);
+      let verifiedIcon = createDeckVerifiedIcon(data.deckVerified?.resolved_category);
       if (verifiedIcon) platforms.prepend(verifiedIcon);
-      let protonMedal = createProtonDbMedal(appId, data.protonDb.tier);
+      let protonMedal = createProtonDbMedal(appId, data.protonDb?.tier);
       if (protonMedal) platforms.prepend(protonMedal);
 
       if (data.sdhq.rating) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -2,7 +2,7 @@
 const MessageType = {
   PROTON_DB: "protonDb",
   DECK_VERIFIED: "deckVerified",
-  PROTON_DB_AND_DECK_VERIFIED: "protonDb_and_deckVerified"
+  ALL: "all"
 }
 
 /** Names of the Deck Verification. */
@@ -108,8 +108,8 @@ function handleSearchResults() {
 
     // when background service responds with data, display it
     port.onMessage.addListener(({type, appId, data}) => {
-      if (type !== MessageType.PROTON_DB_AND_DECK_VERIFIED) return;
-      let {protonDb, deckVerified} = data;
+      if (type !== MessageType.ALL) return;
+      let {protonDb, deckVerified, sdhq} = data;
       let row = appRows.get(appId);
       if (!row) return;
       let iconRow = row.querySelector(".col.search_name.ellipsis").children[1];
@@ -122,7 +122,7 @@ function handleSearchResults() {
     // request data from background service
     for (let [appId, row] of appRows) {
       port.postMessage({
-        type: MessageType.PROTON_DB_AND_DECK_VERIFIED,
+        type: MessageType.ALL,
         appId
       })
     }
@@ -241,7 +241,7 @@ function handleFrontPage() {
     }
 
     port.onMessage.addListener(({type, appId, data}) => {
-      if (type !== MessageType.PROTON_DB_AND_DECK_VERIFIED) return;
+      if (type !== MessageType.ALL) return;
       let hero = appHeroes.get(appId);
       if (!hero) return;
       let platforms = hero.querySelector(".platforms");
@@ -252,7 +252,7 @@ function handleFrontPage() {
     });
 
     for (let [appId, hero] of appHeroes) {
-      port.postMessage({type: MessageType.PROTON_DB_AND_DECK_VERIFIED, appId});
+      port.postMessage({type: MessageType.ALL, appId});
     }
   }
 }

--- a/contentScript.js
+++ b/contentScript.js
@@ -335,11 +335,11 @@ function handleFrontPage() {
       let protonMedal = createProtonDbMedal(appId, data.protonDb.tier);
       if (protonMedal) platforms.prepend(protonMedal);
 
-      if (data.rating) {
+      if (data.sdhq.rating) {
         let sdhqRatingHtml = `
         <div class="sdhq-front-page">
           <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/sdhq-logo.svg" height="30px">
-          <img src="https://steamdeckhq.com/misc/rating-${data.rating.acf.sdhq_rating}-star.svg" height="25px">
+          <img src="https://steamdeckhq.com/misc/rating-${data.sdhq.rating.acf.sdhq_rating}-star.svg" height="25px">
         </div>
         `;
         let sdhqRatingElement = parser

--- a/contentScript.js
+++ b/contentScript.js
@@ -310,6 +310,19 @@ function handleFrontPage() {
       if (verifiedIcon) platforms.prepend(verifiedIcon);
       let protonMedal = createProtonDbMedal(appId, data.protonDb.tier);
       if (protonMedal) platforms.prepend(protonMedal);
+
+      if (data.rating) {
+        let sdhqRatingHtml = `
+        <div class="sdhq-front-page">
+          <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/sdhq-logo.svg" height="30px">
+          <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/rating-${data.rating.acf.sdhq_rating}-star.svg" height="25px">
+        </div>
+        `;
+        let sdhqRatingElement = parser
+          .parseFromString(sdhqRatingHtml, "text/html")
+          .querySelector("div");
+        hero.append(sdhqRatingElement);
+      }
     });
 
     for (let [appId, hero] of appHeroes) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -205,7 +205,6 @@ function handleAppPage() {
             ></img>
             <div class="sdhq-separator"></div>
             <picture class="sdhq-author-avatar" data-tooltip-text="Reviewed By: ${rating.author_meta.display_name}">
-              <source srcset="">
               <source srcset="${avatar?.mpp_avatar.full}">
               <img src="https://steamdeckhq.com/wp-content/uploads/2022/06/cropped-sdhq-icon.png">
             </picture>

--- a/firefox.manifest.json
+++ b/firefox.manifest.json
@@ -16,7 +16,8 @@
   ],
   "permissions": [
     "https://store.steampowered.com/*",
-    "https://www.protondb.com/app/*"
+    "https://www.protondb.com/app/*",
+    "https://steamdeckhq.com/*"
   ],
   "icons": {
     "16": "icon/icon16.png",

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -79,6 +79,40 @@
     border-radius: 2px;
 }
 
+.sdhq-logo {
+    display: flex;
+    justify-content: center;
+}
+.sdhq-logo img {
+    width: 220px;
+}
+.sdhq-review-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+}
+.sdhq-review-row .sdhq-star-rating {
+    height: 40px;
+}
+.sdhq-author-avatar * {
+    height: 40px;
+    border-radius: 50%;
+}
+.sdhq-separator {
+    height: 38px;
+    width: 2px;
+    background-color: white;
+    border-radius: 1px;
+}
+.sdhq-nav-button {
+    order: -7;
+}
+.sdhq-nav-button img {
+    filter: brightness(0) invert(1);
+    background: none;
+}
+
 /* Front Page Styles */
 .store_main_capsule .platforms {
     display: flex;

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -133,3 +133,8 @@
     align-content: center;
     align-items: center;
 }
+@media (max-width: 910px) {
+    .sdhq-front-page {
+        bottom: 70px;
+    }
+}

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -17,6 +17,13 @@
     height: 20px;
 }
 
+.search_released {
+    line-height: inherit !important;
+    display: inline-flex !important;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .protondb-search-medal {
     color: black;
     height: 20px !important;
@@ -27,6 +34,10 @@
     margin: 0 2px 0 0;
     align-items: center;
     display: inline-flex !important;
+}
+
+.sdhq-search-rating img {
+    height: 14px;
 }
 
 /* App Page Styles */

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -121,3 +121,15 @@
 .store_main_capsule .platforms span {
     display: flex;
 }
+.sdhq-front-page {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 5;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 0 10px 0 0;
+    padding: 2px;
+    display: flex;
+    align-content: center;
+    align-items: center;
+}

--- a/great_on_deck.css
+++ b/great_on_deck.css
@@ -23,6 +23,13 @@
     flex-direction: column;
     justify-content: center;
 }
+@media (max-width: 720px) {
+    .search_released {
+        flex-direction: row;
+        gap: 5px;
+        width: fit-content !important;
+    }
+}
 
 .protondb-search-medal {
     color: black;


### PR DESCRIPTION
All pages that this extension modifies now may also show the Game Review Ratings from Steam Deck HQ.

This one closes #8.